### PR TITLE
Disable automatic building of FBX on compilation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(ozz_sample_testing_loops 20 CACHE INT "Number of loops while running sample 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/build-utils/cmake/modules/")
 
 # Detects Fbx SDK, required to build Fbx pipeline.
-if(ozz_build_tools AND ozz_build_fbx)
+if(ozz_build_fbx)
 
   # Select a msvc runtime compatible with ozz_build_msvc_rt_dll
   set(FBX_MSVC_RT_DLL ${ozz_build_msvc_rt_dll})
@@ -56,9 +56,6 @@ if(ozz_build_tools AND ozz_build_fbx)
     message("Fbx SDK not found, FBX tools libraries and samples will be skipped.")
     set(ozz_build_fbx OFF)
   endif()
-else()
-  # Disables fbx if tools are disabled
-  set(ozz_build_fbx OFF)
 endif()
 
 # Include ozz cmake parameters and scripts

--- a/src/animation/offline/fbx/CMakeLists.txt
+++ b/src/animation/offline/fbx/CMakeLists.txt
@@ -25,6 +25,8 @@ install(TARGETS ozz_animation_fbx DESTINATION lib)
 
 fuse_target("ozz_animation_fbx")
 
+if(ozz_build_tools)
+
 add_executable(fbx2ozz
   fbx2ozz.h
   fbx2ozz.cc
@@ -137,3 +139,5 @@ endforeach()
 add_custom_target(BUILD_DATA ALL
   DEPENDS ${all_outputs}
   VERBATIM)
+
+endif()


### PR DESCRIPTION
> Disable automatic building of FBX on compilation.
> Нужно, чтобы он не собирал fbx файлы при компиляции.

via @YuraTim 